### PR TITLE
WIP Convert to a custom element

### DIFF
--- a/client/autocomplete.css
+++ b/client/autocomplete.css
@@ -1,0 +1,70 @@
+.aa-container {
+	display: inline-block;
+	position: relative;
+	width: 300px;
+}
+
+.algolia-autocomplete {
+	width: 100%;
+}
+
+.algolia-autocomplete .aa-input,
+.algolia-autocomplete .aa-hint {
+	width: 100%;
+}
+
+.algolia-autocomplete .aa-hint {
+	color: #999;
+}
+
+.aa-input-search {
+	border: 1px solid #000;
+	padding: 0.5em 1em 0.5em 0.5em;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	font-size: 1em;
+}
+
+/* hide default browser "x" button */
+.aa-input-search::-webkit-search-decoration,
+.aa-input-search::-webkit-search-cancel-button,
+.aa-input-search::-webkit-search-results-button,
+.aa-input-search::-webkit-search-results-decoration {
+	display: none;
+}
+
+.aa-input-icon {
+	height: 16px;
+	width: 16px;
+	position: absolute;
+	top: 50%;
+	right: 15px;
+	transform: translateY(-50%);
+	fill: #e4e4e4;
+}
+
+.aa-dropdown-menu {
+	box-sizing: border-box;
+	width: 100%;
+	background-color: #fff;
+	border: 1px solid #999;
+	border-top: none;
+}
+
+.aa-dropdown-menu .aa-suggestion {
+	cursor: pointer;
+	padding: 0.4em;
+	font-family: system-ui, sans-serif;
+	min-height: 30px;
+	display: flex;
+	align-items: center;
+}
+
+.aa-dropdown-menu .aa-suggestion.aa-cursor {
+	background-color: #b2d7ff;
+}
+
+.aa-suggestion img {
+	margin-right: 0.4em;
+}

--- a/client/autocomplete.js
+++ b/client/autocomplete.js
@@ -1,0 +1,43 @@
+class R4Autocomplete extends HTMLElement {
+	connectedCallback() {
+		this.render()
+		this.enableAutocomplete()
+	}
+
+	render() {
+		this.innerHTML = `<div class="aa-container">
+	<input type="search" class="aa-input-search" placeholder="Search Radio4000 channels…" autocomplete="off" />
+	<svg class="aa-input-icon" viewBox="654 -372 1664 1664">
+		<path d="M1806,332c0-123.3-43.8-228.8-131.5-316.5C1586.8-72.2,1481.3-116,1358-116s-228.8,43.8-316.5,131.5  C953.8,103.2,910,208.7,910,332s43.8,228.8,131.5,316.5C1129.2,736.2,1234.7,780,1358,780s228.8-43.8,316.5-131.5  C1762.2,560.8,1806,455.3,1806,332z M2318,1164c0,34.7-12.7,64.7-38,90s-55.3,38-90,38c-36,0-66-12.7-90-38l-343-342  c-119.3,82.7-252.3,124-399,124c-95.3,0-186.5-18.5-273.5-55.5s-162-87-225-150s-113-138-150-225S654,427.3,654,332  s18.5-186.5,55.5-273.5s87-162,150-225s138-113,225-150S1262.7-372,1358-372s186.5,18.5,273.5,55.5s162,87,225,150s113,138,150,225  S2062,236.7,2062,332c0,146.7-41.3,279.7-124,399l343,343C2305.7,1098.7,2318,1128.7,2318,1164z" />
+	</svg>
+</div>`
+	}
+
+	enableAutocomplete() {
+		var client = algoliasearch('7FFSURJR0X', 'dba2e03ef95f278d5fbe76d4cd80b6bf')
+		var index = client.initIndex('radio4000_channels')
+		var inputElement = this.querySelector('input')
+		var hideImages = this.getAttribute('hide-images') !== null
+		var instance = autocomplete(inputElement, {hint: true}, [
+			{
+				source: autocomplete.sources.hits(index, {hitsPerPage: 5}),
+				displayKey: 'title',
+				templates: {
+					// This is the HTML template for each search result.
+					suggestion({image, title}) {
+						if (!image || hideImages) return title
+						var thumbnail = `https://res.cloudinary.com/radio4000/image/upload/w_50,h_50,c_thumb,q_60/${image}`
+						return `<img width="30" src="${thumbnail}" alt=""><span>${title}</span>`
+					}
+				}
+			}
+		])
+
+		// Send a custom event up.
+		instance.on('autocomplete:selected', (event, suggestion, dataset) => {
+			this.dispatchEvent(new CustomEvent('selected', {detail: suggestion}))
+		})
+	}
+}
+
+customElements.define('r4-autocomplete', R4Autocomplete)

--- a/client/index.html
+++ b/client/index.html
@@ -1,116 +1,25 @@
-<style>
-	.aa-input-container {
-		display: inline-block;
-		position: relative;
-	}
-
-	.aa-input-search {
-		width: 300px;
-		border: 1px solid #000;
-		padding: 0.5em 1em 0.5em 0.5em;
-		box-sizing: border-box;
-		-webkit-appearance: none;
-		-moz-appearance: none;
-		appearance: none;
-		font-size: 1em;
-	}
-
-	.aa-input-search::-webkit-search-decoration,
-	.aa-input-search::-webkit-search-cancel-button,
-	.aa-input-search::-webkit-search-results-button,
-	.aa-input-search::-webkit-search-results-decoration {
-		display: none;
-	}
-
-	.aa-input-icon {
-		height: 16px;
-		width: 16px;
-		position: absolute;
-		top: 50%;
-		right: 16px;
-		transform: translateY(-50%);
-		fill: #e4e4e4;
-	}
-
-	.aa-dropdown-menu {
-		background-color: #fff;
-		border: 1px solid #000;
-		min-width: 300px;
-		margin-top: 0;
-		box-sizing: border-box;
-	}
-
-	/* Search results (algolia calls them suggestions) */
-	.aa-suggestion {
-		font-family: system-ui, sans-serif;
-		padding: 0 0.5em;
-		cursor: pointer;
-		display: flex;
-		align-items: center;
-		min-height: 2.5em;
-	}
-	.aa-suggestion + .aa-suggestion {
-		border-top: 1px solid rgba(228, 228, 228, 0.6);
-	}
-	.aa-suggestion:hover,
-	.aa-suggestion.aa-cursor {
-		background-color: black;
-		color: white;
-	}
-	.aa-suggestion img {
-		margin-right: 0.4em;
-	}
-</style>
-
 <p>
 	This is a test of an search autoomplete with Algolia. Whenever you select a result, it will be
 	logged to the console.
 </p>
 
-<div class="aa-input-container" id="aa-input-container">
-	<input
-		type="search"
-		id="aa-search-input"
-		class="aa-input-search"
-		placeholder="Search for Radio4000 channels…"
-		autocomplete="off"
-	/>
-	<svg class="aa-input-icon" viewBox="654 -372 1664 1664">
-		<path
-			d="M1806,332c0-123.3-43.8-228.8-131.5-316.5C1586.8-72.2,1481.3-116,1358-116s-228.8,43.8-316.5,131.5  C953.8,103.2,910,208.7,910,332s43.8,228.8,131.5,316.5C1129.2,736.2,1234.7,780,1358,780s228.8-43.8,316.5-131.5  C1762.2,560.8,1806,455.3,1806,332z M2318,1164c0,34.7-12.7,64.7-38,90s-55.3,38-90,38c-36,0-66-12.7-90-38l-343-342  c-119.3,82.7-252.3,124-399,124c-95.3,0-186.5-18.5-273.5-55.5s-162-87-225-150s-113-138-150-225S654,427.3,654,332  s18.5-186.5,55.5-273.5s87-162,150-225s138-113,225-150S1262.7-372,1358-372s186.5,18.5,273.5,55.5s162,87,225,150s113,138,150,225  S2062,236.7,2062,332c0,146.7-41.3,279.7-124,399l343,343C2305.7,1098.7,2318,1128.7,2318,1164z"
-		/>
-	</svg>
-</div>
-
-
 <!-- Include AlgoliaSearch JS Client and autocomplete.js library -->
-<script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearchLite.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/autocomplete.js@0.29.0/dist/autocomplete.min.js"></script>
+<script async src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearchLite.min.js"></script>
+<script async src="https://cdn.jsdelivr.net/npm/autocomplete.js@0.29.0/dist/autocomplete.min.js"></script>
 
+<!-- and our custom wrapper -->
+<link rel="stylesheet" href="autocomplete.css">
+<script async src="autocomplete.js"></script>
 
-<script>
-	var client = algoliasearch('7FFSURJR0X', 'dba2e03ef95f278d5fbe76d4cd80b6bf')
-	var index = client.initIndex('radio4000_channels')
+<p>This is how it works out of the box.</p>
+<r4-autocomplete></r4-autocomplete>
 
-	autocomplete('#aa-search-input', {hint: true}, [{
-		source: autocomplete.sources.hits(index, {hitsPerPage: 5}),
-		displayKey: 'title',
-		templates: {
-			// Use this to modify the HTML template for each suggestion.
-			suggestion: function(model) {
-				return `
-					${typeof model.image !== undefined && `<img width="30" src="https://res.cloudinary.com/radio4000/image/upload/w_50,h_50,c_thumb,q_60/${model.image}" alt="">`}
-					<span>${model.title}</span>`
-			}
-		}
-	}]).on('autocomplete:selected', function(event, suggestion, dataset) {
-		console.log(suggestion, dataset)
-		document.querySelector('#debug').innerText = JSON.stringify(suggestion)
-	})
-</script>
+<p>Eexample without images</p>
+<r4-autocomplete hide-images></r4-autocomplete>
 
-<code id="debug"></code>
-
-<br />
-<br />
-<img src="algolia-powered-by.svg" />
+ <script>
+	 var el = document.querySelector('r4-autocomplete')
+		el.addEventListener('selected', (event) => {
+			console.log(event.detail)
+		})
+ </script>


### PR DESCRIPTION
To make it easier to reuse. Now, it will look this:

```html
<!-- Include the AlgoliaSearch and autocomplete.js libraries -->
<script async src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearchLite.min.js"></script>
<script async src="https://cdn.jsdelivr.net/npm/autocomplete.js@0.29.0/dist/autocomplete.min.js"></script>

<!-- styles and scripts for our custom element -->
<link rel="stylesheet" href="autocomplete.css">
<script async src="autocomplete.js"></script>

<r4-autocomplete></r4-autocomplete>

<script>
  var el = document.querySelector('r4-autocomplete')
  el.addEventListener('selected', (event) => {
    console.log(event.detail)
    // event.detail is the r4 channel model you selected
  })
</script>
```

. I wonder how we can reduce the amount of dependencies you have to define.Tthe styles could be inlined in the custom element buut. and what about the 2 algolia deps? Could also concatenate all three scripts but then we'd need build....